### PR TITLE
Feature/Training and generation with memory_saver enabled

### DIFF
--- a/audiocraft/data/music_dataset.py
+++ b/audiocraft/data/music_dataset.py
@@ -278,14 +278,20 @@ class MusicTensorDataset(torch.utils.data.Dataset):
     Args:
         path (Path or str): Path to the folder with pairs of samples. The path has to have
             folders each having two files, named encodec_encoding.pt and attributes.pt
-        random(bool): Whether to getitem randomly or complying with idx
+        randomized(bool): Whether to getitem randomly or complying with idx
+        desired_num_samples(int): Equals to updates_per_epoch*batch_size. Used to calculate dataset_multiplier.
+            Eventually dataset_multiplier*num_samples should be close to desired_num_samples
+
     """
-    def __init__(self, path, randomized=True):
+    def __init__(self, path, randomized=True, desired_num_samples=100):
         logging.info(f'KM: Creating MusicTensorDataset with path: {path} with random = {randomized}')
         self.path = path
 
         self.folders = self.get_valid_folders()
         self.random = randomized
+
+        dataset_multiplier = max(int(desired_num_samples/len(self.folders)), 1)
+        self.folders = self.folders*dataset_multiplier
 
     def get_valid_folders(self):
         """
@@ -318,4 +324,4 @@ class MusicTensorDataset(torch.utils.data.Dataset):
             folder_index = idx
 
         folder = os.path.join(self.path, self.folders[folder_index])
-        return torch.load(os.path.join(folder, 'encodec_encoding.pt')), torch.load(os.path.join(folder, 'attributes.pt'))
+        return torch.load(os.path.join(folder, 'encodec_encoding.pt')), (self.folders[folder_index], torch.load(os.path.join(folder, 'attributes.pt')))

--- a/audiocraft/models/builders.py
+++ b/audiocraft/models/builders.py
@@ -95,7 +95,7 @@ def get_lm_model(cfg: omegaconf.DictConfig) -> LMModel:
         cls_free_guidance = dict_from_config(getattr(cfg, 'classifier_free_guidance'))
         cfg_prob, cfg_coef = cls_free_guidance['training_dropout'], cls_free_guidance['inference_coef']
         fuser = get_condition_fuser(cfg)
-        condition_provider = get_conditioner_provider(kwargs["dim"], cfg).to(cfg.device)
+        condition_provider = get_conditioner_provider(kwargs["dim"], cfg).to(cfg.device) if not cfg.memory_saver else None
         if len(fuser.fuse2cond['cross']) > 0:  # enforce cross-att programmatically
             kwargs['cross_attention'] = True
         if codebooks_pattern_cfg.modeling is None:

--- a/audiocraft/models/builders.py
+++ b/audiocraft/models/builders.py
@@ -95,7 +95,7 @@ def get_lm_model(cfg: omegaconf.DictConfig) -> LMModel:
         cls_free_guidance = dict_from_config(getattr(cfg, 'classifier_free_guidance'))
         cfg_prob, cfg_coef = cls_free_guidance['training_dropout'], cls_free_guidance['inference_coef']
         fuser = get_condition_fuser(cfg)
-        condition_provider = get_conditioner_provider(kwargs["dim"], cfg).to(cfg.device) if not cfg.memory_saver else None
+        condition_provider = get_conditioner_provider(kwargs["dim"], cfg).to(cfg.device) if not cfg.memory_saver.enable else None
         if len(fuser.fuse2cond['cross']) > 0:  # enforce cross-att programmatically
             kwargs['cross_attention'] = True
         if codebooks_pattern_cfg.modeling is None:

--- a/audiocraft/models/genmodel.py
+++ b/audiocraft/models/genmodel.py
@@ -43,7 +43,8 @@ class BaseGenModel(ABC):
         self.lm = lm
         self.cfg: tp.Optional[omegaconf.DictConfig] = None
         # Just to be safe, let's put everything in eval mode.
-        self.compression_model.eval()
+        if self.compression_model is not None:
+            self.compression_model.eval()
         self.lm.eval()
 
         if hasattr(lm, 'cfg'):
@@ -51,7 +52,7 @@ class BaseGenModel(ABC):
             assert isinstance(cfg, omegaconf.DictConfig)
             self.cfg = cfg
 
-        if self.cfg is not None:
+        if (self.cfg is not None) and (self.compression_model is not None):
             self.compression_model = get_wrapped_compression_model(self.compression_model, self.cfg)
 
         if max_duration is None:

--- a/audiocraft/models/genmodel.py
+++ b/audiocraft/models/genmodel.py
@@ -13,6 +13,8 @@ provide easy access to the generation API.
 
 from abc import ABC, abstractmethod
 import typing as tp
+from pathlib import Path
+import os
 
 import omegaconf
 import torch
@@ -21,8 +23,11 @@ from .encodec import CompressionModel
 from .lm import LMModel
 from .builders import get_wrapped_compression_model
 from ..data.audio_utils import convert_audio
-from ..modules.conditioners import ConditioningAttributes
+from ..modules.conditioners import ConditioningAttributes, ConditionType
 from ..utils.autocast import TorchAutocast
+
+ConditionTensors = tp.Dict[str, ConditionType]
+CFGConditions = tp.Union[ConditionTensors, tp.Tuple[ConditionTensors, ConditionTensors]]
 
 
 class BaseGenModel(ABC):
@@ -149,19 +154,48 @@ class BaseGenModel(ABC):
             return self.generate_audio(tokens), tokens
         return self.generate_audio(tokens)
 
-    def generate(self, descriptions: tp.List[str], progress: bool = False, return_tokens: bool = False) \
+    def read_condition_tensors(self, paths_to_descriptions: tp.List[tp.Union[str, Path]]) \
+            -> tp.Tuple[tp.List[ConditioningAttributes], torch.Tensor]:
+        """Load conditional tensors from the paths. Each path should contain one description.
+
+        Args:
+            paths_to_descriptions (list of str or Path): A list of strings or list of paths that contain the path to
+                saved pre-processed condition dictionary of tensors that are outputs of T5 Conditioner. Each file should
+                contain dictionary with keys: attributes and prompt_tokens.
+        """
+        conditions = []
+        masks = []
+
+        for path in paths_to_descriptions:
+            description = torch.load(path)
+            conditions.append(description['description'][0])
+            masks.append(description['description'][1])
+
+        return {'description': (torch.cat(conditions, 0).to(self.device), torch.cat(masks, 0).to(self.device))}
+
+    def generate(self, descriptions: tp.List[tp.Union[str, Path]], progress: bool = False, return_tokens: bool = False, memory_saver: bool=False) \
             -> tp.Union[torch.Tensor, tp.Tuple[torch.Tensor, torch.Tensor]]:
         """Generate samples conditioned on text.
 
         Args:
-            descriptions (list of str): A list of strings used as text conditioning.
+            descriptions (list of str or Paths): A list of strings used as text conditioning. KM: If memory_saver is True
+                these will be treated as paths to descriptions.
             progress (bool, optional): Flag to display progress of the generation process. Defaults to False.
+            memory_saver (bool, optional): KM: If True, descriptions will be treated like paths to saved tensors that are
+                pre-processed using T5 Conditioner.
         """
-        attributes, prompt_tokens = self._prepare_tokens_and_attributes(descriptions, None)
-        for attribute in attributes:
-            print(attribute)
+        if memory_saver and (not all([os.path.isfile(desc) for desc in descriptions])):
+            raise ValueError('If memory_saver is True, the descriptions parameter should contain paths to the pre-processed description vectors')
+
+        if not memory_saver:
+            attributes, prompt_tokens = self._prepare_tokens_and_attributes(descriptions, None)
+            condition_tensors = {}
+        else:
+            condition_tensors = self.read_condition_tensors(descriptions)
+            attributes, prompt_tokens = None, None
+
         assert prompt_tokens is None
-        tokens = self._generate_tokens(attributes, prompt_tokens, progress)
+        tokens = self._generate_tokens(attributes, prompt_tokens, progress, condition_tensors)
         if return_tokens:
             return self.generate_audio(tokens), tokens
         return self.generate_audio(tokens)
@@ -193,14 +227,16 @@ class BaseGenModel(ABC):
             return self.generate_audio(tokens), tokens
         return self.generate_audio(tokens)
 
-    def _generate_tokens(self, attributes: tp.List[ConditioningAttributes],
-                         prompt_tokens: tp.Optional[torch.Tensor], progress: bool = False) -> torch.Tensor:
+
+    def _generate_tokens(self, attributes: tp.Optional[tp.List[ConditioningAttributes]], prompt_tokens: tp.Optional[torch.Tensor],
+                         progress: bool = False,  condition_tensors: tp.Optional[CFGConditions] = {}) -> torch.Tensor:
         """Generate discrete audio tokens given audio prompt and/or conditions.
 
         Args:
-            attributes (list of ConditioningAttributes): Conditions used for generation (here text).
+            attributes (list of ConditioningAttributes, optional): Conditions used for generation (here text).
             prompt_tokens (torch.Tensor, optional): Audio prompt used for continuation.
             progress (bool, optional): Flag to display progress of the generation process. Defaults to False.
+            condition_tensors (CFGConditions): Pre-processed attributes as an alternative to providing attributes.
         Returns:
             torch.Tensor: Generated audio, of shape [B, C, T], T is defined by the generation params.
         """
@@ -229,7 +265,7 @@ class BaseGenModel(ABC):
             # generate by sampling from LM, simple case.
             with self.autocast:
                 gen_tokens = self.lm.generate(
-                    prompt_tokens, attributes,
+                    prompt_tokens, attributes, condition_tensors,
                     callback=callback, max_gen_len=total_gen_len, **self.generation_params)
 
         else:
@@ -249,7 +285,7 @@ class BaseGenModel(ABC):
                 max_gen_len = int(chunk_duration * self.frame_rate)
                 with self.autocast:
                     gen_tokens = self.lm.generate(
-                        prompt_tokens, attributes,
+                        prompt_tokens, attributes, condition_tensors,
                         callback=callback, max_gen_len=max_gen_len, **self.generation_params)
                 if prompt_tokens is None:
                     all_tokens.append(gen_tokens)

--- a/audiocraft/models/lm.py
+++ b/audiocraft/models/lm.py
@@ -242,6 +242,7 @@ class LMModel(StreamingModule):
         assert K == self.num_codebooks, "Sequence shape must match the specified number of codebooks"
         input_ = sum([self.emb[k](sequence[:, k]) for k in range(K)])
         if condition_tensors is None:
+            assert self.condition_provider is not None, "If condition_tensors are not provided, condition provider should not be None"
             assert not self._is_streaming, "Conditions tensors should be precomputed when streaming."
             # apply dropout modules
             conditions = self.cfg_dropout(conditions)

--- a/audiocraft/models/loaders.py
+++ b/audiocraft/models/loaders.py
@@ -100,7 +100,7 @@ def _delete_param(cfg: DictConfig, full_name: str):
     OmegaConf.set_struct(cfg, True)
 
 
-def load_lm_model(file_or_url_or_id: tp.Union[Path, str], device='cpu', cache_dir: tp.Optional[str] = None):
+def load_lm_model(file_or_url_or_id: tp.Union[Path, str], device='cpu', cache_dir: tp.Optional[str] = None, memory_saver: bool = False):
     pkg = load_lm_model_ckpt(file_or_url_or_id, cache_dir=cache_dir)
     cfg = OmegaConf.create(pkg['xp.cfg'])
     cfg.device = str(device)
@@ -108,6 +108,7 @@ def load_lm_model(file_or_url_or_id: tp.Union[Path, str], device='cpu', cache_di
         cfg.dtype = 'float32'
     else:
         cfg.dtype = 'float16'
+    cfg.memory_saver.enable = memory_saver
     _delete_param(cfg, 'conditioners.self_wav.chroma_stem.cache_path')
     _delete_param(cfg, 'conditioners.args.merge_text_conditions_p')
     _delete_param(cfg, 'conditioners.args.drop_desc_p')

--- a/audiocraft/models/musicgen.py
+++ b/audiocraft/models/musicgen.py
@@ -53,7 +53,7 @@ class MusicGen(BaseGenModel):
         self.set_generation_params(duration=15)  # default duration
 
     @staticmethod
-    def get_pretrained(name: str = 'facebook/musicgen-melody', device=None):
+    def get_pretrained(name: str = 'facebook/musicgen-melody', device=None, memory_saver=False):
         """Return pretrained model, we provide four models:
         - facebook/musicgen-small (300M), text to music,
           # see: https://huggingface.co/facebook/musicgen-small
@@ -84,7 +84,7 @@ class MusicGen(BaseGenModel):
             name = _HF_MODEL_CHECKPOINTS_MAP[name]
 
         lm = load_lm_model(name, device=device)
-        compression_model = load_compression_model(name, device=device)
+        compression_model = None if memory_saver else load_compression_model(name, device=device)
         if 'self_wav' in lm.condition_provider.conditioners:
             lm.condition_provider.conditioners['self_wav'].match_len_on_eval = True
             lm.condition_provider.conditioners['self_wav']._use_masking = False

--- a/audiocraft/solvers/base.py
+++ b/audiocraft/solvers/base.py
@@ -40,7 +40,8 @@ class StandardSolver(ABC, flashy.BaseSolver):
         self.logger.info(f"Instantiating solver {self.__class__.__name__} for XP {self.xp.sig}")
         self.logger.info(f"All XP logs are stored in {self.xp.folder}")
         self.cfg = cfg
-        self.memory_saver = cfg.memory_saver
+        self.memory_saver = cfg.memory_saver.enable
+        self.compression_frame_rate = cfg.memory_saver.compression_frame_rate
         self.device = cfg.device
         self.model: nn.Module
         self._continue_best_source_keys = ['best_state', 'fsdp_best_state']

--- a/audiocraft/solvers/base.py
+++ b/audiocraft/solvers/base.py
@@ -549,7 +549,7 @@ class StandardSolver(ABC, flashy.BaseSolver):
             self.logger.warning("Fake loading for benchmarking: re-using first batch")
             batch = next(iter(loader))
             loader = [batch] * updates_per_epoch  # type: ignore
-        lp = self.log_progress(self.current_stage, loader, total=updates_per_epoch, updates=self.log_updates)
+        lp = self.log_progress(self.current_stage, loader, total=len(loader), updates=self.log_updates)
         average = flashy.averager()  # epoch wise average
         instant_average = flashy.averager()  # average between two logging
         metrics: dict = {}

--- a/audiocraft/solvers/builders.py
+++ b/audiocraft/solvers/builders.py
@@ -37,6 +37,7 @@ class DatasetType(Enum):
     AUDIO = "audio"
     MUSIC = "music"
     SOUND = "sound"
+    MUSIC_MEMORY_SAVER = "music_memory_saver"
 
 
 def get_solver(cfg: omegaconf.DictConfig) -> StandardSolver:
@@ -349,6 +350,9 @@ def get_audio_datasets(cfg: omegaconf.DictConfig,
             dataset = data.sound_dataset.SoundDataset.from_meta(path, **kwargs)
         elif dataset_type == DatasetType.AUDIO:
             dataset = data.info_audio_dataset.InfoAudioDataset.from_meta(path, return_info=return_info, **kwargs)
+        elif dataset_type == DatasetType.MUSIC_MEMORY_SAVER:
+            random_sample_selection = getattr(cfg, "random_sample_selection", True)
+            dataset = data.music_dataset.MusicTensorDataset(path, random_sample_selection)
         else:
             raise ValueError(f"Dataset type is unsupported: {dataset_type}")
 
@@ -358,7 +362,7 @@ def get_audio_datasets(cfg: omegaconf.DictConfig,
             batch_size=batch_size,
             num_workers=num_workers,
             seed=seed,
-            collate_fn=dataset.collater if return_info else None,
+            collate_fn=dataset.collater if return_info and (dataset_type != DatasetType.MUSIC_MEMORY_SAVER) else None,
             shuffle=shuffle,
         )
         dataloaders[split] = loader

--- a/audiocraft/solvers/builders.py
+++ b/audiocraft/solvers/builders.py
@@ -351,8 +351,8 @@ def get_audio_datasets(cfg: omegaconf.DictConfig,
         elif dataset_type == DatasetType.AUDIO:
             dataset = data.info_audio_dataset.InfoAudioDataset.from_meta(path, return_info=return_info, **kwargs)
         elif dataset_type == DatasetType.MUSIC_MEMORY_SAVER:
-            random_sample_selection = getattr(cfg, "random_sample_selection", True)
-            dataset = data.music_dataset.MusicTensorDataset(path, random_sample_selection)
+            random_sample_selection = getattr(cfg, "random_sample_selection", False)
+            dataset = data.music_dataset.MusicTensorDataset(path, random_sample_selection, batch_size*cfg.optim.updates_per_epoch)
         else:
             raise ValueError(f"Dataset type is unsupported: {dataset_type}")
 

--- a/audiocraft/solvers/musicgen.py
+++ b/audiocraft/solvers/musicgen.py
@@ -360,7 +360,7 @@ class MusicGenSolver(base.StandardSolver):
         check_synchronization_points = idx == 1 and self.device == 'cuda'
 
         if self.cfg.memory_saver.enable:
-            audio_tokens, conditions = batch
+            audio_tokens, (_, conditions) = batch
             condition_tensors, padding_mask = conditions['condition_tensors'], conditions['padding_mask']
             audio_tokens = audio_tokens.to(self.device)
             for k, v in condition_tensors.items():
@@ -491,7 +491,7 @@ class MusicGenSolver(base.StandardSolver):
 
             condition_tensors = None
         else:
-            _, conditions = batch
+            _, (foldername, conditions) = batch
             prompt_tokens = None #KM TODO: Add this for continuation. Not hard. take batch[0](i.e. audio_tokens)[:, :x]
             attributes = None
             prompt_audio = None
@@ -527,6 +527,8 @@ class MusicGenSolver(base.StandardSolver):
             'prompt_audio': prompt_audio,
             'prompt_tokens': prompt_tokens,
         }
+        if self.memory_saver:
+            gen_outputs['foldername'] = foldername
         return gen_outputs
 
     def generate_audio(self) -> dict:
@@ -539,7 +541,6 @@ class MusicGenSolver(base.StandardSolver):
         lp = self.log_progress(generate_stage_name, loader, total=updates, updates=self.log_updates)
 
         dataset = get_dataset_from_loader(loader)
-        print('Config dataset: ', self.cfg.dataset)
         dataset_duration = dataset.segment_duration if isinstance(dataset, AudioDataset) else self.cfg.dataset.segment_duration
         assert dataset_duration is not None
         # assert isinstance(dataset, AudioDataset)

--- a/audiocraft/solvers/musicgen.py
+++ b/audiocraft/solvers/musicgen.py
@@ -619,15 +619,16 @@ class MusicGenSolver(base.StandardSolver):
                 metrics['rtf'] = rtf
 
             else:
-                hydrated_conditions, sample_generation_params = None, None
+                sample_generation_params = None
                 if self.cfg.generate.lm.unprompted_samples:
                     if not self.cfg.generate.lm.gen_gt_samples: # KM TODO Only supports this one for now
                         gen_unprompted_outputs = self.run_generate_step(
                             batch, gen_duration=target_duration, prompt_duration=None,
                             **self.generation_params)
+                        conditions = [{'condition': foldername} for foldername in gen_unprompted_outputs['foldername']]
                         rtf = -1 # TODO KM Check what this is and if there is workaround
                         sample_manager.add_samples(
-                            gen_unprompted_outputs['gen_tokens'].cpu(), self.epoch, hydrated_conditions,
+                            gen_unprompted_outputs['gen_tokens'].cpu(), self.epoch, conditions,
                             ground_truth_wavs=None, generation_args=sample_generation_params, memory_saver=self.memory_saver)
                         metrics['rtf'] = rtf
 

--- a/audiocraft/solvers/musicgen.py
+++ b/audiocraft/solvers/musicgen.py
@@ -35,7 +35,7 @@ class MusicGenSolver(base.StandardSolver):
     """
 
     def __init__(self, cfg: omegaconf.DictConfig):
-        self.DATASET_TYPE = builders.DatasetType.MUSIC if not cfg.memory_saver else builders.DatasetType.MUSIC_MEMORY_SAVER
+        self.DATASET_TYPE = builders.DatasetType.MUSIC if not cfg.memory_saver.enable else builders.DatasetType.MUSIC_MEMORY_SAVER
         super().__init__(cfg)
         # easier access to sampling parameters
         self.generation_params = {
@@ -114,7 +114,7 @@ class MusicGenSolver(base.StandardSolver):
         """Instantiate models and optimizer."""
         # we can potentially not use all quantizers with which the EnCodec model was trained
         # (e.g. we trained the model with quantizers dropout)
-        if not self.cfg.memory_saver:
+        if not self.cfg.memory_saver.enable:
             self.compression_model = CompressionSolver.wrapped_model_from_checkpoint(
                 self.cfg, self.cfg.compression_model_checkpoint, device=self.device)
             assert self.compression_model.sample_rate == self.cfg.sample_rate, (
@@ -359,7 +359,7 @@ class MusicGenSolver(base.StandardSolver):
         KM UPD: batch is tuple of T5 encoding input_ids and dictionary containing condition_tensors, audio_tokens and padding_mask"""
         check_synchronization_points = idx == 1 and self.device == 'cuda'
 
-        if self.cfg.memory_saver:
+        if self.cfg.memory_saver.enable:
             audio_tokens, conditions = batch
             condition_tensors, padding_mask = conditions['condition_tensors'], conditions['padding_mask']
             audio_tokens = audio_tokens.to(self.device)
@@ -461,43 +461,62 @@ class MusicGenSolver(base.StandardSolver):
                 and the prompt along with additional information.
         """
         bench_start = time.time()
-        audio, meta = batch
-        assert audio.size(0) == len(meta), (
-            f"Mismatch between number of items in audio batch ({audio.size(0)})",
-            f" and in metadata ({len(meta)})"
-        )
-        # prepare attributes
-        attributes = [x.to_condition_attributes() for x in meta]
-        # TODO: Add dropout for chroma?
+        if not self.memory_saver:
+            audio, meta = batch
+            assert audio.size(0) == len(meta), (
+                f"Mismatch between number of items in audio batch ({audio.size(0)})",
+                f" and in metadata ({len(meta)})"
+            )
+            # prepare attributes
+            attributes = [x.to_condition_attributes() for x in meta]
+            # TODO: Add dropout for chroma?
 
-        # prepare audio prompt
-        if prompt_duration is None:
+            # prepare audio prompt
+            if prompt_duration is None:
+                prompt_audio = None
+            else:
+                assert prompt_duration < gen_duration, "Prompt duration must be lower than target generation duration"
+                prompt_audio_frames = int(prompt_duration * self.compression_model.sample_rate)
+                prompt_audio = audio[..., :prompt_audio_frames]
+
+            # get audio tokens from compression model
+            if prompt_audio is None or prompt_audio.nelement() == 0:
+                num_samples = len(attributes)
+                prompt_tokens = None
+            else:
+                num_samples = None
+                prompt_audio = prompt_audio.to(self.device)
+                prompt_tokens, scale = self.compression_model.encode(prompt_audio)
+                assert scale is None, "Compression model in MusicGen should not require rescaling."
+
+            condition_tensors = None
+        else:
+            _, conditions = batch
+            prompt_tokens = None #KM TODO: Add this for continuation. Not hard. take batch[0](i.e. audio_tokens)[:, :x]
+            attributes = None
             prompt_audio = None
-        else:
-            assert prompt_duration < gen_duration, "Prompt duration must be lower than target generation duration"
-            prompt_audio_frames = int(prompt_duration * self.compression_model.sample_rate)
-            prompt_audio = audio[..., :prompt_audio_frames]
-
-        # get audio tokens from compression model
-        if prompt_audio is None or prompt_audio.nelement() == 0:
-            num_samples = len(attributes)
-            prompt_tokens = None
-        else:
-            num_samples = None
-            prompt_audio = prompt_audio.to(self.device)
-            prompt_tokens, scale = self.compression_model.encode(prompt_audio)
-            assert scale is None, "Compression model in MusicGen should not require rescaling."
+            audio = None
+            condition_tensors, padding_mask = conditions['condition_tensors'], conditions['padding_mask']
+            num_samples = condition_tensors['description'][0].shape[0]
+            # audio_tokens = audio_tokens.to(self.device)
+            for k, v in condition_tensors.items():
+                if isinstance(v, torch.Tensor):
+                    condition_tensors[k] = condition_tensors[k].to(self.device)
+                elif isinstance(v, list) or isinstance(v, tuple):
+                    condition_tensors[k] = tuple(
+                        [condition_tensors[k][i].to(self.device) for i in range(len(condition_tensors[k]))])
 
         # generate by sampling from the LM
-        with self.autocast:
-            total_gen_len = math.ceil(gen_duration * self.compression_model.frame_rate)
+        with (self.autocast):
+            total_gen_len = math.ceil(gen_duration * self.compression_model.frame_rate) if not self.memory_saver else\
+                math.ceil(gen_duration * self.compression_frame_rate)
             gen_tokens = self.model.generate(
-                prompt_tokens, attributes, max_gen_len=total_gen_len,
+                prompt_tokens, attributes, condition_tensors, max_gen_len=total_gen_len,
                 num_samples=num_samples, **self.generation_params)
 
         # generate audio from tokens
         assert gen_tokens.dim() == 3
-        gen_audio = self.compression_model.decode(gen_tokens, None)
+        gen_audio = self.compression_model.decode(gen_tokens, None) if not self.memory_saver else None
 
         bench_end = time.time()
         gen_outputs = {
@@ -520,9 +539,10 @@ class MusicGenSolver(base.StandardSolver):
         lp = self.log_progress(generate_stage_name, loader, total=updates, updates=self.log_updates)
 
         dataset = get_dataset_from_loader(loader)
-        dataset_duration = dataset.segment_duration
+        print('Config dataset: ', self.cfg.dataset)
+        dataset_duration = dataset.segment_duration if isinstance(dataset, AudioDataset) else self.cfg.dataset.segment_duration
         assert dataset_duration is not None
-        assert isinstance(dataset, AudioDataset)
+        # assert isinstance(dataset, AudioDataset)
         target_duration = self.cfg.generate.lm.gen_duration
         prompt_duration = self.cfg.generate.lm.prompt_duration
         if target_duration is None:
@@ -559,42 +579,57 @@ class MusicGenSolver(base.StandardSolver):
         metrics: dict = {}
         average = flashy.averager()
         for batch in lp:
-            audio, meta = batch
-            # metadata for sample manager
-            hydrated_conditions = get_hydrated_conditions(meta)
-            sample_generation_params = {
-                **{f'classifier_free_guidance_{k}': v for k, v in self.cfg.classifier_free_guidance.items()},
-                **self.generation_params
-            }
-            if self.cfg.generate.lm.unprompted_samples:
-                if self.cfg.generate.lm.gen_gt_samples:
-                    # get the ground truth instead of generation
-                    self.logger.warn(
-                        "Use ground truth instead of audio generation as generate.lm.gen_gt_samples=true")
-                    gen_unprompted_audio = audio
-                    rtf = 1.
-                else:
-                    gen_unprompted_outputs = self.run_generate_step(
-                        batch, gen_duration=target_duration, prompt_duration=None,
+            if not self.memory_saver:
+                audio, meta = batch
+                # metadata for sample manager
+                hydrated_conditions = get_hydrated_conditions(meta)
+                sample_generation_params = {
+                    **{f'classifier_free_guidance_{k}': v for k, v in self.cfg.classifier_free_guidance.items()},
+                    **self.generation_params
+                }
+
+                if self.cfg.generate.lm.unprompted_samples:
+                    if self.cfg.generate.lm.gen_gt_samples:
+                        # get the ground truth instead of generation
+                        self.logger.warn(
+                            "Use ground truth instead of audio generation as generate.lm.gen_gt_samples=true")
+                        gen_unprompted_audio = audio
+                        rtf = 1.
+                    else:
+                        gen_unprompted_outputs = self.run_generate_step(
+                            batch, gen_duration=target_duration, prompt_duration=None,
+                            **self.generation_params)
+                        gen_unprompted_audio = gen_unprompted_outputs['gen_audio'].cpu()
+                        rtf = gen_unprompted_outputs['rtf']
+                    sample_manager.add_samples(
+                        gen_unprompted_audio, self.epoch, hydrated_conditions,
+                        ground_truth_wavs=audio, generation_args=sample_generation_params)
+
+                if self.cfg.generate.lm.prompted_samples:  # KM TODO: Currently doesn't support continuation
+                    gen_outputs = self.run_generate_step(
+                        batch, gen_duration=target_duration, prompt_duration=prompt_duration,
                         **self.generation_params)
-                    gen_unprompted_audio = gen_unprompted_outputs['gen_audio'].cpu()
-                    rtf = gen_unprompted_outputs['rtf']
-                sample_manager.add_samples(
-                    gen_unprompted_audio, self.epoch, hydrated_conditions,
-                    ground_truth_wavs=audio, generation_args=sample_generation_params)
+                    gen_audio = gen_outputs['gen_audio'].cpu()
+                    prompt_audio = gen_outputs['prompt_audio'].cpu()
+                    sample_manager.add_samples(
+                        gen_audio, self.epoch, hydrated_conditions,
+                        prompt_wavs=prompt_audio, ground_truth_wavs=audio,
+                        generation_args=sample_generation_params)
+                metrics['rtf'] = rtf
 
-            if self.cfg.generate.lm.prompted_samples:
-                gen_outputs = self.run_generate_step(
-                    batch, gen_duration=target_duration, prompt_duration=prompt_duration,
-                    **self.generation_params)
-                gen_audio = gen_outputs['gen_audio'].cpu()
-                prompt_audio = gen_outputs['prompt_audio'].cpu()
-                sample_manager.add_samples(
-                    gen_audio, self.epoch, hydrated_conditions,
-                    prompt_wavs=prompt_audio, ground_truth_wavs=audio,
-                    generation_args=sample_generation_params)
+            else:
+                hydrated_conditions, sample_generation_params = None, None
+                if self.cfg.generate.lm.unprompted_samples:
+                    if not self.cfg.generate.lm.gen_gt_samples: # KM TODO Only supports this one for now
+                        gen_unprompted_outputs = self.run_generate_step(
+                            batch, gen_duration=target_duration, prompt_duration=None,
+                            **self.generation_params)
+                        rtf = -1 # TODO KM Check what this is and if there is workaround
+                        sample_manager.add_samples(
+                            gen_unprompted_outputs['gen_tokens'].cpu(), self.epoch, hydrated_conditions,
+                            ground_truth_wavs=None, generation_args=sample_generation_params, memory_saver=self.memory_saver)
+                        metrics['rtf'] = rtf
 
-            metrics['rtf'] = rtf
             metrics = average(metrics)
 
         flashy.distrib.barrier()

--- a/audiocraft/train.py
+++ b/audiocraft/train.py
@@ -131,6 +131,7 @@ def init_seed_and_system(cfg):
 
 @hydra_main(config_path='../config', config_name='config', version_base='1.1')
 def main(cfg):
+    print(cfg)
     init_seed_and_system(cfg)
 
     # Setup logging both to XP specific folder, and to stderr.

--- a/audiocraft/utils/best_state.py
+++ b/audiocraft/utils/best_state.py
@@ -34,11 +34,12 @@ class BestStateDictManager(flashy.state.StateDictSource):
         dtype (torch.dtype): Data type for the state parameters.
     """
     def __init__(self, device: tp.Union[torch.device, str] = 'cpu',
-                 dtype: tp.Optional[torch.dtype] = None):
+                 dtype: tp.Optional[torch.dtype] = None, memory_saver: bool=False):
         self.device = device
         self.states: dict = {}
         self.param_ids: dict = defaultdict(dict)
         self.dtype = dtype
+        self.memory_saver = memory_saver
 
     def _get_parameter_ids(self, state_dict):
         return {id(p): name for name, p in state_dict.items() if isinstance(p, torch.Tensor)}
@@ -78,4 +79,6 @@ class BestStateDictManager(flashy.state.StateDictSource):
     def load_state_dict(self, state: flashy.state.StateDict):
         for name, sub_state in state.items():
             for k, v in sub_state.items():
+                if self.memory_saver and k.startswith('condition_provider.conditioners.description.output_proj'):
+                    continue
                 self.states[name][k].copy_(v)

--- a/audiocraft/utils/samples/manager.py
+++ b/audiocraft/utils/samples/manager.py
@@ -193,6 +193,31 @@ class SampleManager:
         audio_path = audio_write(stem_path, wav, **self.xp.cfg.generate.audio)
         return audio_path
 
+    def _store_tensor(self, encoded_wav: torch.Tensor, stem_path: Path, overwrite: bool = False) -> Path:
+        """Stores the tensor with the given stem path using the XP's configuration.
+
+        Args:
+            encoded_wav (torch.Tensor): Audio to store.
+            stem_path (Path): Path in sample output directory with file stem to use.
+            overwrite (bool): When False (default), skips storing an existing audio file.
+        Returns:
+            Path: The path at which the audio is stored.
+        """
+        existing_paths = [
+            path for path in stem_path.parent.glob(stem_path.stem + '.*')
+            if path.suffix != '.json'
+        ]
+        exists = len(existing_paths) > 0
+        if exists and overwrite:
+            logger.warning(f"Overwriting existing encoded_wav file with stem path {stem_path}")
+        elif exists:
+            return existing_paths[0]
+        
+        path = Path(str(stem_path) + '.pt')
+        path.parent.mkdir(exist_ok=True, parents=True)
+        torch.save(encoded_wav, path)
+        return stem_path
+
     def add_sample(self, sample_wav: torch.Tensor, epoch: int, index: int = 0,
                    conditions: tp.Optional[tp.Dict[str, str]] = None, prompt_wav: tp.Optional[torch.Tensor] = None,
                    ground_truth_wav: tp.Optional[torch.Tensor] = None,
@@ -235,11 +260,38 @@ class SampleManager:
             json.dump(asdict(sample), f, indent=2)
         return sample
 
+    def add_encoded_sample(self, encoded_generation: torch.Tensor, epoch: int, index: int = 0,
+                   ) -> Sample:
+        """Adds a single encoded (Encodec encoded) sample.
+        The sample is stored in the XP's sample output directory, under a corresponding epoch folder.
+        Each sample is assigned an id which is computed using the input data. No meta data will be stored
+        anywhere for encoded samples for now.
+
+        Args:
+            encoded_generation (torch.Tensor): generation output of the model to store. Tensor of shape [N_codebooks, shape].
+            epoch (int): current training epoch.
+            index (int): helpful to differentiate samples from the same batch.
+        Returns:
+            Sample: The saved sample.
+        """
+        sample_id = self._get_sample_id(index, None, None)
+        reuse_id = self.map_reference_to_sample_id
+        prompt, ground_truth, conditions = None, None, None
+        generation_args = {}
+        sample_path = self._store_tensor(encoded_generation, self.base_folder / str(epoch) / sample_id, overwrite=True)
+        duration = encoded_generation.shape[-1] / self.xp.cfg.memory_saver.compression_frame_rate
+        sample = Sample(sample_id, str(sample_path), epoch, duration, conditions, prompt, ground_truth, generation_args)
+        self.samples.append(sample)
+        with open(sample_path.with_suffix('.json'), 'w') as f:
+            json.dump(asdict(sample), f, indent=2)
+        return sample
+
     def add_samples(self, samples_wavs: torch.Tensor, epoch: int,
                     conditioning: tp.Optional[tp.List[tp.Dict[str, tp.Any]]] = None,
                     prompt_wavs: tp.Optional[torch.Tensor] = None,
                     ground_truth_wavs: tp.Optional[torch.Tensor] = None,
-                    generation_args: tp.Optional[tp.Dict[str, tp.Any]] = None) -> tp.List[Sample]:
+                    generation_args: tp.Optional[tp.Dict[str, tp.Any]] = None,
+                    memory_saver: bool = False) -> tp.List[Sample]:
         """Adds a batch of samples.
         The samples are stored in the XP's sample output directory, under a corresponding
         epoch folder. Each sample is assigned an id which is computed using the input data and their batch index.
@@ -260,10 +312,13 @@ class SampleManager:
         """
         samples = []
         for idx, wav in enumerate(samples_wavs):
-            prompt_wav = prompt_wavs[idx] if prompt_wavs is not None else None
-            gt_wav = ground_truth_wavs[idx] if ground_truth_wavs is not None else None
-            conditions = conditioning[idx] if conditioning is not None else None
-            samples.append(self.add_sample(wav, epoch, idx, conditions, prompt_wav, gt_wav, generation_args))
+            if memory_saver:
+                samples.append(self.add_encoded_sample(wav, epoch, idx))
+            else:
+                prompt_wav = prompt_wavs[idx] if prompt_wavs is not None else None
+                gt_wav = ground_truth_wavs[idx] if ground_truth_wavs is not None else None
+                conditions = conditioning[idx] if conditioning is not None else None
+                samples.append(self.add_sample(wav, epoch, idx, conditions, prompt_wav, gt_wav, generation_args))
         return samples
 
     def get_samples(self, epoch: int = -1, max_epoch: int = -1, exclude_prompted: bool = False,

--- a/audiocraft/utils/samples/manager.py
+++ b/audiocraft/utils/samples/manager.py
@@ -260,7 +260,7 @@ class SampleManager:
             json.dump(asdict(sample), f, indent=2)
         return sample
 
-    def add_encoded_sample(self, encoded_generation: torch.Tensor, epoch: int, index: int = 0,
+    def add_encoded_sample(self, encoded_generation: torch.Tensor, epoch: int, conditions: tp.Dict[str, tp.Any]=None, index: int = 0,
                    ) -> Sample:
         """Adds a single encoded (Encodec encoded) sample.
         The sample is stored in the XP's sample output directory, under a corresponding epoch folder.
@@ -276,7 +276,7 @@ class SampleManager:
         """
         sample_id = self._get_sample_id(index, None, None)
         reuse_id = self.map_reference_to_sample_id
-        prompt, ground_truth, conditions = None, None, None
+        prompt, ground_truth = None, None
         generation_args = {}
         sample_path = self._store_tensor(encoded_generation, self.base_folder / str(epoch) / sample_id, overwrite=True)
         duration = encoded_generation.shape[-1] / self.xp.cfg.memory_saver.compression_frame_rate
@@ -313,7 +313,7 @@ class SampleManager:
         samples = []
         for idx, wav in enumerate(samples_wavs):
             if memory_saver:
-                samples.append(self.add_encoded_sample(wav, epoch, idx))
+                samples.append(self.add_encoded_sample(wav, epoch, conditioning[idx], idx))
             else:
                 prompt_wav = prompt_wavs[idx] if prompt_wavs is not None else None
                 gt_wav = ground_truth_wavs[idx] if ground_truth_wavs is not None else None

--- a/config/solver/default.yaml
+++ b/config/solver/default.yaml
@@ -4,6 +4,7 @@
 # Please don't update this file directly. Instead use distinct configuration files
 # to override the below configuration.
 solver: ???
+memory_saver: false
 
 fsdp:
   use: false  # should we use FSDP.
@@ -23,7 +24,7 @@ deadlock:
 
 dataset:
   batch_size: ???
-  num_workers: 10
+  num_workers: 4
   segment_duration: null
   num_samples: null
   return_info: false

--- a/config/solver/musicgen/default.yaml
+++ b/config/solver/musicgen/default.yaml
@@ -44,9 +44,9 @@ dataset:
   train:
     num_samples: 1000000 # need a randomly large number here for AudioDataset
   valid:
-    num_samples: 10000
+    num_samples: 10
   generate:
-    num_samples: 50
+    num_samples: 2
 
 metrics:
   fad:
@@ -77,7 +77,7 @@ metrics:
       argmax: true
 
 generate:
-  every: 25
+  every: 3
   num_workers: 5
   path: samples
   audio:
@@ -115,7 +115,7 @@ checkpoint:
 
 optim:
   epochs: 200
-  updates_per_epoch: 2000
+  updates_per_epoch: 200
   lr: 1e-4
   optimizer: adamw
   max_norm: 1.0

--- a/config/solver/musicgen/musicgen_base_32khz.yaml
+++ b/config/solver/musicgen/musicgen_base_32khz.yaml
@@ -11,12 +11,14 @@ defaults:
 
 autocast: true
 autocast_dtype: float16
-
 # EnCodec large trained on mono-channel music audio sampled at 32khz
 # with a total stride of 640 leading to 50 frames/s.
 # rvq.n_q=4, rvq.bins=2048, no quantization dropout
 # (transformer_lm card and n_q must be compatible)
 compression_model_checkpoint: //pretrained/facebook/encodec_32khz
+
+#KM NEW PARAMETERS
+memory_saver: false
 
 channels: 1
 sample_rate: 32000
@@ -25,8 +27,8 @@ deadlock:
   use: true  # deadlock detection
 
 dataset:
-  batch_size: 192  # 32 GPUs
-  segment_duration: 30
+  batch_size: 1  # 32 GPUs
+  segment_duration: 10
   sample_on_weight: false  # Uniform sampling all the way
   sample_on_duration: false  # Uniform sampling all the way
 
@@ -43,7 +45,7 @@ optim:
   ema:
     use: true
     updates: 10
-    device: cuda
+    device: cpu
 
 logging:
   log_tensorboard: true

--- a/config/solver/musicgen/musicgen_base_32khz.yaml
+++ b/config/solver/musicgen/musicgen_base_32khz.yaml
@@ -18,7 +18,9 @@ autocast_dtype: float16
 compression_model_checkpoint: //pretrained/facebook/encodec_32khz
 
 #KM NEW PARAMETERS
-memory_saver: false
+memory_saver:
+  enable: true
+  compression_frame_rate: 50
 
 channels: 1
 sample_rate: 32000
@@ -33,6 +35,7 @@ dataset:
   sample_on_duration: false  # Uniform sampling all the way
 
 generate:
+  every: 2
   lm:
     use_sampling: true
     top_k: 250

--- a/config/solver/musicgen/musicgen_base_32khz.yaml
+++ b/config/solver/musicgen/musicgen_base_32khz.yaml
@@ -30,7 +30,8 @@ deadlock:
 
 dataset:
   batch_size: 1  # 32 GPUs
-  segment_duration: 10
+  segment_duration: 30
+    # segment_duration: 5
   sample_on_weight: false  # Uniform sampling all the way
   sample_on_duration: false  # Uniform sampling all the way
 


### PR DESCRIPTION
## Feature description

Adds functionality to train and infer the model without loading Encodec and T5 models. 

## Solution Details

**During Training**

A new config parameter is added to the `solver` (see `musicgen_base_32khz.yaml` solver). Looks like the following:
```
memory_saver:
  enable: true
  compression_frame_rate: 50
```

If `memory_saver.enable` is `True`, the pipeline does not load Encodec and T5 models. Instead, it now expects the training samples to be pair of encodings containing T5 encodings and Encodec encodings. Imagine, `dset/audio/example_preprocessed.yaml` shows train path to `train: dataset/preprocessed_dataset`. `preprocessed_dataset` folder has to contain folders, each representing one sample. Each folder has to have two files named: `'encodec_encoding.pt'` and `'attributes.pt'`. 
- `encodec_encodings` represent audio tokens and are expected to have [K, T] dimensions, where K is the number of codebooks, T is the number of timestamps
- `attributes` represent conditioning attributes after encoding. Currently, it is expected to have only 'description' attributes. The 'wav' attribute wasn't tested yet, so please avoid using it. The file contains dictionary with two keys: 'conditioning_tensors' and 'padding_mask'. 'conditioning_tensors' key contains another dict with one key: 'description' that contains a tuple of Tensors with shapes [K, model_hidden_dimensions (i.e. 1024 for small model)] and [K]. 'padding_mask' key contains one tensor with shape [K, T]. In my observation this should always be tensor with all True-s.

If the train, valid, generation folders are constructed in correct way, a new Dataset and DataLoader will be created to handle reading and processing te encoded data. Evaluation using 3rd party tools hasn't been tested, but probably they won't work with memory_saver. After each generation step, the generated tensors will be stored in the same folder as they would've without memory_saver. The resulting tensors are size [K, T] and have to be decoded before can be heard. You can use the following code for decoding and listening in Jupyter Notebook:

```
import IPython.display as ipd

from audiocraft.models import encodec, loaders, builders
from audiocraft.utils import utils
import omegaconf
import torch

musicgen_model_name = 'facebook/musicgen-small'

#reading generation
encoded_generation = torch.load([PATH_TO_GENERATION])

#Loading Encodec model
pkg = loaders.load_compression_model_ckpt(musicgen_model_name)
cfg = omegaconf.OmegaConf.create(pkg['xp.cfg'])

kwargs = utils.dict_from_config(getattr(cfg, 'encodec'))

encoder_name = kwargs.pop('autoencoder')
quantizer_name = kwargs.pop('quantizer')

encoder, decoder = builders.get_encodec_autoencoder(encoder_name, cfg)
quantizer = builders.get_quantizer(quantizer_name, cfg, encoder.dimension)
frame_rate = kwargs['sample_rate'] // encoder.hop_length
renormalize = kwargs.pop('renormalize', False)
kwargs.pop('renorm', None), type(quantizer), frame_rate
model = encodec.EncodecModel(encoder, decoder, quantizer,
                    frame_rate=frame_rate, renormalize=renormalize, **kwargs)
model.load_state_dict(pkg['best_state'])
model = model.eval()

# decode and listen
melody_waveform_reconstructed = model.decode(encoded_generation.unsqueeze(0), None)
ipd.display(ipd.Audio(melody_waveform_reconstructed[0].detach().numpy(), rate=kwargs['sample_rate']))
```

**During Generation**

For generation, just add `memory_saver=True` to `model.generate(...)` method and instead of description of the generating audio, provide the path to pre-processed T5 encoding of the desired description. The encoding file should be similar to `attributes['conditioning_tensors']` but each element in the tuple should have one additional dimension for the batch and each example has to have null_condition encoding following the example. This means, for one generation, we should have a file containing something similar to:
![image](https://github.com/HrayrMuradyan/MusicGeneration/assets/18456186/09a3047a-c966-4f86-b471-62c2d5330c95)
Notice, how the second vector is made up with zeros. Please, consult with the `audiocraft` codes to see how this condition is generated.

## How this has been tested

**Training**
A dumy dataset with one sample has been created and training was run with `memory_saver` enabled. The codes run and generated samples for epoch 2
![image](https://github.com/HrayrMuradyan/MusicGeneration/assets/18456186/694be0d8-0a4b-43ca-8c21-840a9392604d)

The sample generated was audible

**Generation**
Generated output with both memory_saver = True and False with the same description pre-processed and not processed, respectively. The results were identical. The code for generating both outputs and listening them is as follows:

```
# Generation of outputs
import sys
sys.path.insert(0, '')

from audiocraft.models import MusicGen
import torch

model = MusicGen.get_pretrained('facebook/musicgen-small')
# pre-processed
model.set_generation_params(use_sampling=False, duration=15)
descriptions = ['./dataset/preprocessed_dataset/generate_cfg_conditions.pt']
wav = model.generate(descriptions, memory_saver=True) 
torch.save(wav, "./wav_test_gen.pt")

# not pre-processed
model.set_generation_params(use_sampling=False, duration=15)
descriptions = ['happy rock']
wav = model.generate(descriptions) 
torch.save(wav, 'wav_test_py.pt')

# Comparing and listening
import IPython.display as ipd
import torch

with_pre_processed = torch.load('wav_test_gen.pt')
without_pre_processed = torch.load('wav_test_py.pt')

ipd.display(ipd.Audio(with_pre_processed[0].cpu().detach().numpy(), rate=32000))
ipd.display(ipd.Audio(without_pre_processed[0].cpu().detach().numpy(), rate=32000))
```
