### PR TITLE
Fix for the os.rename in the code

### DIFF
--- a/audiocraft/solvers/base.py
+++ b/audiocraft/solvers/base.py
@@ -14,6 +14,9 @@ import omegaconf
 import torch
 from torch import nn
 
+## HM
+import os
+##
 from .. import optim
 from ..optim import fsdp
 from ..utils import checkpoint
@@ -470,6 +473,11 @@ class StandardSolver(ABC, flashy.BaseSolver):
             self.save_checkpoints()
         self._start_epoch()
         if flashy.distrib.is_rank_zero():
+            ## HM
+            if os.name == 'nt':
+                if os.path.exists(self.xp.link.history_file):
+                    os.remove(self.xp.link.history_file)
+            ##
             self.xp.link.update_history(self.history)
 
     def run_epoch(self):


### PR DESCRIPTION
## Fix for the checkpoint renaming for Windows OS

**Description**

When trying to rename the temporary checkpoint file named `checkpoint.pt.tmp` to `checkpoint.pt` an exception was raised due to file handling system of the Windows:
```
FileExistsError: [WinError 183] Cannot create a file when that file already exists: 'C:\\tmp\\audiocraft_MusicGen\\xps\\16839212\\checkpoint.th.tmp' -> 'C:\\tmp\\audiocraft_MusicGen\\xps\\16839212\\checkpoint.th'
```

This means that the file that is opened in the system can't be renamed as Windows locks them. 
The problem is that there are three cases where a renaming process is done and in two of them, the renaming is done outside of the audio craft. Specifically, in Dora and Flashy.

**Solution**

I added a condition checking the operation system, if the OS is Windows, then the old file is removed, and the renaming works fine. This may slow down a bit for Windows training, however, it is the fastest straightforward solution.