### PR TITLE
fix/loading_model_memory_saver_missing

### DIFF
--- a/audiocraft/models/loaders.py
+++ b/audiocraft/models/loaders.py
@@ -108,7 +108,7 @@ def load_lm_model(file_or_url_or_id: tp.Union[Path, str], device='cpu', cache_di
         cfg.dtype = 'float32'
     else:
         cfg.dtype = 'float16'
-    cfg.memory_saver.enable = memory_saver
+    OmegaConf.update(cfg, "memory_saver.enable", memory_saver)
     _delete_param(cfg, 'conditioners.self_wav.chroma_stem.cache_path')
     _delete_param(cfg, 'conditioners.args.merge_text_conditions_p')
     _delete_param(cfg, 'conditioners.args.drop_desc_p')


### PR DESCRIPTION
**Description**
Fix of the memory_saver key missing when loading pre-trained model for generation.

Fixes issue #5 

**Solution**

When trying to assign `cfg.memory_saver.enable`, `memory_saver` didn't exist, thus the error. The correct way of assigning was to use `OmegaConfig.update` method.

**Test**

The solution was tested by generating a music using the following code:

```
from audiocraft.models import MusicGen
import IPython.display as ipd

model = MusicGen.get_pretrained('facebook/musicgen-small')

descriptions = ['Russian hip-hop beat in latino style']
wav = model.generate(descriptions)

ipd.display(ipd.Audio(wav.cpu().detach().numpy()[0], rate=32000))
```

Additionally, you can see newly added `memory_saver.enable` key in the model's config **at the end**:

`model.cfg`
![image](https://github.com/HrayrMuradyan/MusicGeneration/assets/18456186/977fda02-c4ae-4ad5-bc4d-66f104f43fab)

