### PR TITLE
Added token level and description level dropouts for attributes during the training

### DIFF
--- a/audiocraft/solvers/builders.py
+++ b/audiocraft/solvers/builders.py
@@ -369,7 +369,11 @@ def get_audio_datasets(cfg: omegaconf.DictConfig,
             dataset = data.info_audio_dataset.InfoAudioDataset.from_meta(path, return_info=return_info, **kwargs)
         elif dataset_type == DatasetType.MUSIC_MEMORY_SAVER:
             random_sample_selection = getattr(cfg, "random_sample_selection", False)
-            dataset = data.music_dataset.MusicTensorDataset(path, random_sample_selection, batch_size*cfg.optim.updates_per_epoch)
+            if split == 'train':
+                dataset = data.music_dataset.MusicTensorDataset(path, random_sample_selection, batch_size*cfg.optim.updates_per_epoch,
+                                                            token_dropout_p=cfg.memory_saver.token_dropout_p, description_dropout_p=cfg.memory_saver.description_dropout_p)
+            else:
+                dataset = data.music_dataset.MusicTensorDataset(path, random_sample_selection, None)
         else:
             raise ValueError(f"Dataset type is unsupported: {dataset_type}")
 

--- a/config/solver/musicgen/musicgen_base_32khz.yaml
+++ b/config/solver/musicgen/musicgen_base_32khz.yaml
@@ -21,6 +21,8 @@ compression_model_checkpoint: //pretrained/facebook/encodec_32khz
 memory_saver:
   enable: true
   compression_frame_rate: 50
+  token_dropout_p: 0.1
+  description_dropout_p: 0.1
 
 channels: 1
 sample_rate: 32000
@@ -29,14 +31,14 @@ deadlock:
   use: true  # deadlock detection
 
 dataset:
-  batch_size: 1  # 32 GPUs
+  batch_size: 6  # 32 GPUs
   segment_duration: 30
     # segment_duration: 5
   sample_on_weight: false  # Uniform sampling all the way
   sample_on_duration: false  # Uniform sampling all the way
 
 generate:
-  every: 2
+  every: 5
   lm:
     use_sampling: true
     top_k: 250
@@ -49,7 +51,7 @@ optim:
   ema:
     use: true
     updates: 10
-    device: cpu
+    device: cuda
 
 logging:
   log_tensorboard: true


### PR DESCRIPTION
# Feature Description
Adds token level and description level dropouts during training

- token level randomly removes tokens from attributes input_ids
- description level randomly removes the whole description

# Solution Details
Firstly, the loaded attributes file goes through token level dropout. Given the probability in the config file, it randomly drops or keeps each token in the description. Those tokens that are dropped are replaced by vector of 0s and corresponding attention_masks are replaced with 0.
If a token in the middle of the sentence is dropped, all following tokens are shifted to the left, and the resulting vector is padded to have the necessary shape (applies both to attention masks and input ids)

Secondly, the resulting attributes are passed to description level dropout, which either keeps or drops ALL tokens in the description. If it is applied, everything is replaced with 0s while also preserving the shape. 

# How this has been tested
In local notebook